### PR TITLE
feat(US-002): Password Reset / Forgot Password Flow

### DIFF
--- a/DOCUMENTATION/PROJECT.md
+++ b/DOCUMENTATION/PROJECT.md
@@ -439,6 +439,68 @@ flowchart LR
     H --> I[JSON Response + X-CSRFToken Header]
 ```
 
+### 5.8 Password Reset Flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant ForgotAPI as POST /forgot-password
+    participant ResetAPI as POST /reset-password/<token>
+    participant DB as PostgreSQL
+    participant Mail as SMTP Server
+    participant Validator as Password Validator
+
+    rect rgb(200, 220, 255)
+        Note over User,Mail: Step 1: Request Password Reset
+        User->>ForgotAPI: POST {"email": "user@example.com"}
+        ForgotAPI->>DB: Check if user exists
+        alt User found
+            ForgotAPI->>ForgotAPI: Generate time-limited token (URLSafeTimedSerializer)
+            ForgotAPI->>DB: Store token in last_password_reset_token
+            ForgotAPI->>Mail: Send reset email with link
+        end
+        ForgotAPI-->>User: 200 — (same response regardless, prevents enumeration)
+    end
+
+    rect rgb(200, 255, 220)
+        Note over User,Validator: Step 2: Reset Password with Token
+        User->>Mail: Click reset link in email
+        Mail->>User: Redirect to reset form
+        User->>ResetAPI: POST /reset-password/<token> {"new_password": "..."}
+        ResetAPI->>ResetAPI: Deserialize token (check expiration - 30 min)
+        
+        alt Token expired or invalid
+            ResetAPI-->>User: 422 — Invalid or expired token
+        end
+        
+        ResetAPI->>DB: Get user by token
+        ResetAPI->>ResetAPI: Verify token matches stored last_password_reset_token
+        
+        alt Token already used
+            ResetAPI-->>User: 422 — Token already redeemed
+        end
+        
+        ResetAPI->>Validator: Validate password strength (min score 70)
+        
+        alt Password too weak
+            ResetAPI-->>User: 422 — Password does not meet requirements
+        end
+        
+        ResetAPI->>DB: Update user.password (hashed)
+        ResetAPI->>DB: Clear user.jwt_session_id (invalidate all sessions)
+        ResetAPI->>DB: Clear user.last_password_reset_token (prevent reuse)
+        ResetAPI-->>User: 200 — Password reset successful, please log in again
+    end
+```
+
+**Key Security Features:**
+- **Email Enumeration Prevention:** `/forgot-password` returns identical responses for existing and non-existing emails
+- **Rate Limiting:** `/forgot-password` limited to 3 requests per hour per IP
+- **Token Expiration:** Reset tokens expire after 30 minutes (configurable)
+- **Token Reuse Prevention:** Token is cleared from database after successful reset
+- **Session Invalidation:** User's JWT session is invalidated, forcing a fresh login
+- **Password Strength:** New password validated via external scoring API (minimum score 70)
+
 ---
 
 ## 6. Database Models
@@ -452,6 +514,7 @@ erDiagram
         String password
         DateTime created_on
         String last_activation_token
+        String last_password_reset_token
         Boolean active
         DateTime activated_on
         DateTime deactivated_on
@@ -488,6 +551,9 @@ erDiagram
 | **Authorization Guard** | Custom decorator checking JWT + user existence + activation status | Applied to all protected routes |
 | **Payload Validation** | Custom decorators `validate_generic_payload`, `validate_role_payload` | Validates JSON structure before processing |
 | **Email Activation** | `itsdangerous.URLSafeTimedSerializer` with time-limited tokens | One-time tokens with configurable expiration |
+| **Password Reset** | `itsdangerous.URLSafeTimedSerializer` with time-limited tokens (30 min) | Time-limited reset tokens; stored in DB and cleared after use |
+| **Password Reset Email** | Enumeration prevention (identical responses) + rate limiting (3/hour) | Prevents account discovery; rate limit on forgot-password endpoint |
+| **Session Invalidation** | JWT session ID cleared on password reset | Forces user to re-login after password change |
 | **Circuit Breaker** | PyBreaker with configurable `fail_max` and `reset_timeout` | Protects against external password-scoring API failures |
 | **Input Validation** | email-validator, python-usernames, custom validators | Validates usernames, emails, and password strength |
 | **Configuration Validation** | `validate_config.py` checks all required env vars at startup | Fail-fast on missing configuration |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ A set of tools is provided to help you to create, run and stop the docker contai
 ### Activation account
     The activation account endpoint is located at "/confirm/<token>"
 
+### Forgot password
+    The forgot password endpoint is located at "/forgot-password"
+    Request: POST /forgot-password with {"email": "user@example.com"}
+    Always returns 200 for security (prevents email enumeration)
+    Rate limited to 3 requests per hour
+
+### Reset password
+    The reset password endpoint is located at "/reset-password/<token>"
+    Request: POST /reset-password/<token> with {"new_password": "..."}
+    Validates token expiration (30 minutes by default)
+    Requires password strength validation
+    Clears JWT session to force re-login
+
 ### Swagger documentations
     The swagger UI is located at "/swagger"
 

--- a/config/default.py
+++ b/config/default.py
@@ -117,6 +117,18 @@ RATELIMIT_STORAGE_URI = env.get(
 RATE_LIMIT_LOGIN = env.get("RATE_LIMIT_LOGIN", "5/minute")
 RATE_LIMIT_SIGNUP = env.get("RATE_LIMIT_SIGNUP", "3/minute")
 RATE_LIMIT_DEFAULT = env.get("RATE_LIMIT_DEFAULT", "200/hour")
+RATE_LIMIT_FORGOT_PASSWORD = env.get("RATE_LIMIT_FORGOT_PASSWORD", "3/hour")
+
+################################################################
+# ### Password Reset configuration                         ####
+################################################################
+PASSWORD_RESET_TOKEN_EXPIRATION = int(
+    env.get("PASSWORD_RESET_TOKEN_EXPIRATION", 1800)
+)  # 30 minutes in seconds
+PASSWORD_RESET_EMAIL_SUBJECT = env.get(
+    "PASSWORD_RESET_EMAIL_SUBJECT", "Reset Your Password"
+)
+PASSWORD_RESET_SALT = env.get("PASSWORD_RESET_SALT", "password-reset-salt")
 
 ################################################################
 # ### API with token auth. CSRF protection disabled   ##########

--- a/config/validate_config.py
+++ b/config/validate_config.py
@@ -77,9 +77,14 @@ def validate_env_config(app_config: Config):
         "RATE_LIMIT_SIGNUP",
     ]
 
+    password_reset_required_vars = [
+        "PASSWORD_RESET_SALT",
+    ]
+
     required_vars.extend(gw_required_vars)
     required_vars.extend(resilience_required_vars)
     required_vars.extend(rate_limit_required_vars)
+    required_vars.extend(password_reset_required_vars)
 
     print(required_vars)
     print(

--- a/core/users/models.py
+++ b/core/users/models.py
@@ -64,6 +64,9 @@ class GwUser(db.Model, UserMixin):
     last_activation_token = db.Column(
         db.String(100), unique=False, nullable=True
     )
+    last_password_reset_token = db.Column(
+        db.String(100), unique=False, nullable=True
+    )
     active = db.Column(db.Boolean, nullable=False, default=False)
     activated_on = db.Column(db.DateTime, nullable=True)
     deactivated_on = db.Column(db.DateTime, nullable=True)

--- a/core/users/routes/__init__.py
+++ b/core/users/routes/__init__.py
@@ -6,7 +6,15 @@ import uuid
 from core import login_manager
 from core.users.models import GwUser
 
-from . import email_activation, login, logout, roles, sanity_check, signup
+from . import (
+    email_activation,
+    login,
+    logout,
+    password_reset,
+    roles,
+    sanity_check,
+    signup,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/core/users/routes/password_reset.py
+++ b/core/users/routes/password_reset.py
@@ -1,0 +1,291 @@
+"""Define the routes for password reset functionality."""
+
+import logging
+from os import environ as env
+
+from flask import current_app, jsonify, request
+
+from config.default import (
+    PASSWORD_RESET_SALT,
+    PASSWORD_RESET_TOKEN_EXPIRATION,
+    SECRET_KEY,
+)
+from core import limiter
+from core.auth.api_endpoint_statistics import count_api_calls
+from core.auth.middlewares.validation_token import (
+    confirm_activation_token,
+    generate_activation_token,
+)
+from core.common.error_codes import (
+    __RESPONSE_STATUS_200,
+    __RESPONSE_STATUS_422,
+)
+from core.common.messages import __GENERIC_ERROR, __INVALID_TOKEN_ERROR
+from core.services.validators.passwords import PasswordValidator
+from core.users import users_bp
+from core.users.models import GwUser
+
+logger = logging.getLogger(__name__)
+
+API_TITLE: str = "{}".format(env.get("APP_NAME", "Service-Name"))
+API_PREFIX: str = "/{}/api/".format(API_TITLE)
+API_VERSION: str = "{}".format(env.get("APP_VERSION", "v1.0.0a"))
+BASE_ROUTE: str = "".join([API_PREFIX, API_VERSION])
+ROUTE_FORGOT_PASSWORD: str = "".join([BASE_ROUTE, "/forgot-password"])
+ROUTE_RESET_PASSWORD: str = "".join([BASE_ROUTE, "/reset-password/<token>"])
+
+# Config imports
+WS_SCORING_PASSWORD_URL_API = (
+    current_app.config.get("WS_SCORING_PASSWORD_URL_API")
+    if current_app
+    else env.get("WS_SCORING_PASSWORD_URL_API")
+)
+
+
+@users_bp.route(ROUTE_FORGOT_PASSWORD, methods=["POST"])
+@users_bp.route("/forgot-password", methods=["POST"])
+@limiter.limit(
+    lambda: current_app.config.get("RATE_LIMIT_FORGOT_PASSWORD", "3/hour")
+)
+@count_api_calls
+def forgot_password():
+    """
+    Endpoint to request a password reset.
+
+    Always returns 200 to prevent email enumeration.
+    """
+    try:
+        json = request.get_json()
+
+        if not json:
+            json = {}
+
+        # Extract email
+        email = json.get("email", "").strip()
+
+        if not email:
+            # Return same response for invalid input (prevent enumeration)
+            return (
+                jsonify(
+                    {
+                        "message": (
+                            "If the email exists in our system, a password reset link has been sent to it."
+                        ),
+                        "status": __RESPONSE_STATUS_200,
+                    }
+                ),
+                __RESPONSE_STATUS_200,
+            )
+
+        # Look up user by email
+        user = GwUser.query.filter_by(email=email).first()
+
+        if user:
+            # Generate reset token
+            token = generate_activation_token(
+                SECRET_KEY, PASSWORD_RESET_SALT, email
+            )
+
+            # Store token in database
+            user.last_password_reset_token = token
+            user.save()
+
+            # Send email (delegate to mail service)
+            from server.config.mails import send_password_reset_email
+
+            send_password_reset_email(user, token)
+
+            logger.info(
+                f"Password reset token generated and email sent for user: {email}"
+            )
+
+        # Always return the same response (prevents enumeration)
+        return (
+            jsonify(
+                {
+                    "message": (
+                        "If the email exists in our system, a password reset link has been sent to it."
+                    ),
+                    "status": __RESPONSE_STATUS_200,
+                }
+            ),
+            __RESPONSE_STATUS_200,
+        )
+
+    except Exception as e:
+        logger.error(f"Error in forgot_password endpoint: {str(e)}")
+        return (
+            jsonify(
+                {
+                    "message": (
+                        "If the email exists in our system, a password reset link has been sent to it."
+                    ),
+                    "status": __RESPONSE_STATUS_200,
+                }
+            ),
+            __RESPONSE_STATUS_200,
+        )
+
+
+@users_bp.route(ROUTE_RESET_PASSWORD, methods=["POST"])
+@users_bp.route("/reset-password/<token>", methods=["POST"])
+def reset_password(token):
+    """
+    Endpoint to reset password using a valid token.
+
+    Returns 200 on success, 422 on validation errors (expired token, weak password, etc).
+    """
+    try:
+        # Validate token and extract email
+        email = confirm_activation_token(
+            SECRET_KEY,
+            PASSWORD_RESET_SALT,
+            token,
+            expiration=PASSWORD_RESET_TOKEN_EXPIRATION,
+        )
+
+        if not email:
+            return (
+                jsonify(
+                    {
+                        "message": "Invalid or expired reset token.",
+                        "status": __RESPONSE_STATUS_422,
+                    }
+                ),
+                __RESPONSE_STATUS_422,
+            )
+
+        # Look up user by email
+        user = GwUser.query.filter_by(email=email).first()
+
+        if not user:
+            return (
+                jsonify(
+                    {
+                        "message": "User not found.",
+                        "status": __RESPONSE_STATUS_422,
+                    }
+                ),
+                __RESPONSE_STATUS_422,
+            )
+
+        # Verify token matches the stored token (prevent reuse)
+        if user.last_password_reset_token != token:
+            return (
+                jsonify(
+                    {
+                        "message": (
+                            "Reset token has already been used or is invalid."
+                        ),
+                        "status": __RESPONSE_STATUS_422,
+                    }
+                ),
+                __RESPONSE_STATUS_422,
+            )
+
+        # Validate payload
+        json = request.get_json()
+
+        if not json:
+            json = {}
+
+        new_password = json.get("password", "").strip()
+
+        if not new_password:
+            return (
+                jsonify(
+                    {
+                        "message": "Password is required.",
+                        "status": __RESPONSE_STATUS_422,
+                    }
+                ),
+                __RESPONSE_STATUS_422,
+            )
+
+        # Validate password strength (using existing password validator)
+        global WS_SCORING_PASSWORD_URL_API
+        if not WS_SCORING_PASSWORD_URL_API:
+            WS_SCORING_PASSWORD_URL_API = current_app.config.get(
+                "WS_SCORING_PASSWORD_URL_API"
+            )
+
+        is_valid = PasswordValidator.is_valid_password(
+            url_api=WS_SCORING_PASSWORD_URL_API,
+            password=new_password,
+            has_digits=True,
+            has_lowercase=True,
+            has_spaces=False,
+            has_symbols=True,
+            has_uppercase=True,
+            min_length=10,
+            max_length=50,
+            min_accepted_score=70,
+        )
+
+        if not is_valid:
+            return (
+                jsonify(
+                    {
+                        "message": (
+                            "Password does not meet strength requirements."
+                        ),
+                        "status": __RESPONSE_STATUS_422,
+                    }
+                ),
+                __RESPONSE_STATUS_422,
+            )
+
+        # Update password
+        user.set_password(new_password)
+
+        # Invalidate JWT session
+        user.jwt_session_id = None
+
+        # Clear reset token (prevent reuse)
+        user.last_password_reset_token = None
+
+        # Save changes
+        user.save()
+
+        logger.info(f"Password reset successful for user: {email}")
+
+        return (
+            jsonify(
+                {
+                    "message": (
+                        "Password reset successful. Please log in with your new password."
+                    ),
+                    "status": __RESPONSE_STATUS_200,
+                }
+            ),
+            __RESPONSE_STATUS_200,
+        )
+
+    except Exception as e:
+        logger.error(f"Error in reset_password endpoint: {str(e)}")
+
+        # Determine the type of error (token-related or other)
+        error_message = str(e)
+
+        if "temporary token" in error_message or "max_age" in error_message:
+            return (
+                jsonify(
+                    {
+                        "message": (
+                            "Reset token has expired. Please request a new one."
+                        ),
+                        "status": __RESPONSE_STATUS_422,
+                    }
+                ),
+                __RESPONSE_STATUS_422,
+            )
+
+        return (
+            jsonify(
+                {
+                    "message": __INVALID_TOKEN_ERROR,
+                    "status": __RESPONSE_STATUS_422,
+                }
+            ),
+            __RESPONSE_STATUS_422,
+        )

--- a/server/config/mails.py
+++ b/server/config/mails.py
@@ -20,7 +20,7 @@ def send_password_reset_email(user, token):
     try:
         # Build reset link
         reset_url = url_for(
-            "core.users.routes.password_reset.reset_password",
+            "users.reset_password",
             token=token,
             _external=True,
         )

--- a/server/config/mails.py
+++ b/server/config/mails.py
@@ -1,3 +1,107 @@
-from flask_mail import Mail
+"""Mail configuration and utilities for sending emails."""
+
+import logging
+
+from flask import current_app, url_for
+from flask_mail import Mail, Message
 
 mail = Mail()
+logger = logging.getLogger(__name__)
+
+
+def send_password_reset_email(user, token):
+    """
+    Send password reset email to user.
+
+    Args:
+        user: GwUser instance
+        token: Password reset token
+    """
+    try:
+        # Build reset link
+        reset_url = url_for(
+            "core.users.routes.password_reset.reset_password",
+            token=token,
+            _external=True,
+        )
+
+        # Create email message
+        subject = current_app.config.get(
+            "PASSWORD_RESET_EMAIL_SUBJECT", "Reset Your Password"
+        )
+
+        # HTML version
+        html_body = f"""
+        <html>
+            <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+                <div style="max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #ddd; border-radius: 5px;">
+                    <h2 style="color: #2c3e50;">Password Reset Request</h2>
+                    
+                    <p>Hello {user.username},</p>
+                    
+                    <p>We received a request to reset your password. Click the button below to set a new password.</p>
+                    
+                    <p style="text-align: center; margin: 30px 0;">
+                        <a href="{reset_url}" style="background-color: #3498db; color: white; padding: 12px 30px; text-decoration: none; border-radius: 5px; display: inline-block;">
+                            Reset Password
+                        </a>
+                    </p>
+                    
+                    <p>Or copy and paste this link in your browser:</p>
+                    <p style="background-color: #f4f4f4; padding: 10px; border-radius: 3px; word-break: break-all;">
+                        {reset_url}
+                    </p>
+                    
+                    <p style="color: #e74c3c; font-weight: bold;">⏰ This link expires in 30 minutes.</p>
+                    
+                    <hr style="border: 0; border-top: 1px solid #ddd; margin: 20px 0;">
+                    
+                    <p style="color: #7f8c8d; font-size: 12px;">
+                        <strong>Security Notice:</strong> If you did not request a password reset, please ignore this email. Your account remains secure.
+                    </p>
+                    
+                    <p style="color: #7f8c8d; font-size: 12px;">
+                        Best regards,<br>
+                        The IAM Gateway Team
+                    </p>
+                </div>
+            </body>
+        </html>
+        """
+
+        # Plain text version
+        text_body = f"""
+        Password Reset Request
+
+        Hello {user.username},
+
+        We received a request to reset your password. Click the link below to set a new password.
+
+        Reset Link:
+        {reset_url}
+
+        ⏰ This link expires in 30 minutes.
+
+        ---
+
+        Security Notice: If you did not request a password reset, please ignore this email. Your account remains secure.
+
+        Best regards,
+        The IAM Gateway Team
+        """
+
+        # Send email
+        msg = Message(
+            subject=subject,
+            recipients=[user.email],
+            html=html_body,
+            body=text_body,
+        )
+
+        mail.send(msg)
+        logger.info(f"Password reset email sent to {user.email}")
+
+    except Exception as e:
+        logger.error(
+            f"Failed to send password reset email to {user.email}: {str(e)}"
+        )

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -1,0 +1,253 @@
+"""Test suite for password reset functionality."""
+
+import json
+import unittest
+import uuid
+from unittest.mock import patch
+
+from config.default import (
+    PASSWORD_RESET_SALT,
+    PASSWORD_RESET_TOKEN_EXPIRATION,
+    SECRET_KEY,
+)
+from core import db
+from core.auth.middlewares.validation_token import generate_activation_token
+from core.users.models import GwUser
+from tests import BaseTestClass
+
+
+class PasswordResetTestCase(BaseTestClass):
+    """Test cases for password reset functionality."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Don't call super().setUp() because it creates default users
+        # Instead, create our own app context
+        self.app = self.create_app_context()
+        self.client = self.app.test_client()
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+        # Create tables
+        db.create_all()
+
+        self._test_email = (
+            f"password_reset_test_{uuid.uuid4().hex[:8]}@example.com"
+        )
+        self._test_username = f"password_reset_user_{uuid.uuid4().hex[:8]}"
+        self._test_password = "ValidPassword123!"
+        self._new_password = "NewPassword456!"
+
+    def tearDown(self):
+        """Clean up after tests."""
+        # Delete test user if exists
+        user = GwUser.get_by_email(self._test_email)
+        if user:
+            db.session.delete(user)
+            db.session.commit()
+
+        db.session.close()
+        self.app_context.pop()
+
+    def create_app_context(self):
+        """Create the Flask app for testing."""
+        from core import create_app
+
+        app = create_app(settings_module="config.testing")
+        return app
+
+    def _create_test_user(self):
+        """Create a test user in the database."""
+        user = GwUser(username=self._test_username, email=self._test_email)
+        user.set_password(self._test_password)
+        user.active = True
+        db.session.add(user)
+        db.session.commit()
+        return user
+
+    def test_forgot_password_with_existing_email_sends_email(self):
+        """Test that forgot-password endpoint sends email for existing email."""
+        user = self._create_test_user()
+
+        with patch("server.config.mails.mail.send") as mock_mail:
+            response = self.client.post(
+                "/forgot-password",
+                data=json.dumps({"email": self._test_email}),
+                content_type="application/json",
+            )
+
+            # Should return 200
+            self.assertEqual(response.status_code, 200)
+            data = json.loads(response.data)
+            self.assertEqual(data["status"], 200)
+
+            # Email should be sent
+            mock_mail.assert_called_once()
+
+            # Token should be stored in database
+            updated_user = GwUser.get_by_email(self._test_email)
+            self.assertIsNotNone(updated_user.last_password_reset_token)
+
+    def test_forgot_password_with_nonexisting_email_returns_200(self):
+        """Test that forgot-password returns 200 for non-existing email."""
+        with patch("server.config.mails.mail.send") as mock_mail:
+            response = self.client.post(
+                "/forgot-password",
+                data=json.dumps({"email": "nonexistent@example.com"}),
+                content_type="application/json",
+            )
+
+            # Should return 200 (prevent enumeration)
+            self.assertEqual(response.status_code, 200)
+            data = json.loads(response.data)
+            self.assertEqual(data["status"], 200)
+
+            # Email should NOT be sent
+            mock_mail.assert_not_called()
+
+    def test_forgot_password_response_identical_for_existing_and_nonexisting(
+        self,
+    ):
+        """Test that response is identical for existing and non-existing emails."""
+        user = self._create_test_user()
+
+        with patch("server.config.mails.mail.send"):
+            response1 = self.client.post(
+                "/forgot-password",
+                data=json.dumps({"email": self._test_email}),
+                content_type="application/json",
+            )
+
+        with patch("server.config.mails.mail.send"):
+            response2 = self.client.post(
+                "/forgot-password",
+                data=json.dumps({"email": "nonexistent@example.com"}),
+                content_type="application/json",
+            )
+
+        data1 = json.loads(response1.data)
+        data2 = json.loads(response2.data)
+
+        # Both responses should be identical
+        self.assertEqual(data1["status"], data2["status"])
+        self.assertEqual(data1["message"], data2["message"])
+
+    def test_reset_password_with_valid_token_and_valid_password(self):
+        """Test successful password reset with valid token."""
+        user = self._create_test_user()
+
+        # Generate a valid reset token
+        token = generate_activation_token(
+            SECRET_KEY, PASSWORD_RESET_SALT, self._test_email
+        )
+        user.last_password_reset_token = token
+        db.session.commit()
+
+        response = self.client.post(
+            f"/reset-password/{token}",
+            data=json.dumps({"password": self._new_password}),
+            content_type="application/json",
+        )
+
+        # Should return 200
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data["status"], 200)
+
+        # Password should be updated
+        updated_user = GwUser.get_by_email(self._test_email)
+        self.assertTrue(updated_user.check_password(self._new_password))
+        self.assertFalse(updated_user.check_password(self._test_password))
+
+        # Token should be cleared
+        self.assertIsNone(updated_user.last_password_reset_token)
+
+    def test_reset_password_with_invalid_token(self):
+        """Test reset password with invalid token."""
+        response = self.client.post(
+            "/reset-password/invalid_token_xyz",
+            data=json.dumps({"password": self._new_password}),
+            content_type="application/json",
+        )
+
+        # Should return 422
+        self.assertEqual(response.status_code, 422)
+        data = json.loads(response.data)
+        self.assertEqual(data["status"], 422)
+
+    def test_reset_password_with_already_used_token(self):
+        """Test that reset token cannot be reused."""
+        user = self._create_test_user()
+
+        # Generate and store a token
+        token = generate_activation_token(
+            SECRET_KEY, PASSWORD_RESET_SALT, self._test_email
+        )
+        user.last_password_reset_token = token
+        db.session.commit()
+
+        # First reset should succeed
+        response1 = self.client.post(
+            f"/reset-password/{token}",
+            data=json.dumps({"password": self._new_password}),
+            content_type="application/json",
+        )
+        self.assertEqual(response1.status_code, 200)
+
+        # Try to use the same token again
+        response2 = self.client.post(
+            f"/reset-password/{token}",
+            data=json.dumps({"password": "AnotherPassword789!"}),
+            content_type="application/json",
+        )
+
+        # Should return 422 (token already used or invalid)
+        self.assertEqual(response2.status_code, 422)
+
+    def test_jwt_session_invalidated_after_password_reset(self):
+        """Test that JWT session is invalidated after password reset."""
+        user = self._create_test_user()
+
+        # Set a JWT session ID
+        user.jwt_session_id = "test_session_id_123"
+        db.session.commit()
+
+        # Generate a valid reset token
+        token = generate_activation_token(
+            SECRET_KEY, PASSWORD_RESET_SALT, self._test_email
+        )
+        user.last_password_reset_token = token
+        db.session.commit()
+
+        response = self.client.post(
+            f"/reset-password/{token}",
+            data=json.dumps({"password": self._new_password}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # JWT session should be cleared
+        updated_user = GwUser.get_by_email(self._test_email)
+        self.assertIsNone(updated_user.jwt_session_id)
+
+    def test_forgot_password_rate_limiting(self):
+        """Test that forgot-password endpoint is rate limited."""
+        # Try 4 requests rapidly (3/hour limit)
+        with patch("server.config.mails.mail.send"):
+            for i in range(4):
+                response = self.client.post(
+                    "/forgot-password",
+                    data=json.dumps({"email": f"test{i}@example.com"}),
+                    content_type="application/json",
+                )
+
+                if i < 3:  # First 3 should be OK (3/hour limit)
+                    self.assertEqual(response.status_code, 200)
+                else:
+                    # 4th should hit rate limit
+                    self.assertEqual(response.status_code, 429)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Overview

Implements complete password reset functionality with email-based token workflow for user account recovery.

## Changes

### TASK-002-1: Model Update
- Added `last_password_reset_token` field to `GwUser` model
- Stores current reset token to prevent reuse

### TASK-002-2: POST /forgot-password Endpoint
- Accepts email address (JSON: `{"email": "..."}`)
- Generates time-limited reset token via `itsdangerous.URLSafeTimedSerializer`
- Stores token in database
- Sends password reset email
- **Email enumeration prevention:** Returns HTTP 200 for all emails (existing or non-existing)
- **Rate limiting:** 3 requests per hour per IP
- Location: `core/users/routes/password_reset.py`

### TASK-002-3: POST /reset-password/<token> Endpoint
- Validates token with configurable expiration (30 minutes default)
- Verifies token matches stored value (prevents reuse)
- Validates new password strength via external scoring API (minimum score 70)
- Updates user password (hashed via Werkzeug)
- Clears `jwt_session_id` (invalidates all active JWT sessions)
- Clears token from database (prevents reuse)
- Returns 422 for invalid/expired/reused tokens
- Location: `core/users/routes/password_reset.py`

### TASK-002-4: Email Template
- HTML and plain text versions
- Styled reset button with clickable link
- Expiration notice (30 minutes)
- Security warning for unauthorized requests
- Location: `server/config/mails.py`

### TASK-002-5: Test Suite
- 8 comprehensive test cases
- All tests passing:
  - Email sending with token storage
  - Email enumeration prevention (identical responses)
  - Valid token and password reset
  - Invalid token rejection
  - Token reuse prevention
  - JWT session invalidation
  - Rate limiting enforcement
- Location: `tests/test_password_reset.py`

## Configuration

New environment variables added to `config/default.py`:
- `PASSWORD_RESET_SALT` — Salt for token generation
- `PASSWORD_RESET_TOKEN_EXPIRATION` — Token lifetime (default: 1800 seconds = 30 minutes)
- `PASSWORD_RESET_EMAIL_SUBJECT` — Email subject line
- `RATE_LIMIT_FORGOT_PASSWORD` — Rate limit (default: 3/hour)

Configuration validation enforces `PASSWORD_RESET_SALT` at startup.

## Security Features

✅ **Email Enumeration Prevention** — Same 200 response regardless of email existence  
✅ **Token Security** — Time-limited tokens with database validation  
✅ **Password Strength** — Validated via external scoring API (min score 70)  
✅ **Session Invalidation** — JWT session ID cleared on reset (forces re-login)  
✅ **Token Reuse Prevention** — Token cleared after successful use  
✅ **Rate Limiting** — 3 requests/hour on forgot-password endpoint  
✅ **Configuration Validation** — Fail-fast on missing required env vars  

## Testing

All password reset tests pass:
```
Ran 8 tests in 12.768s
OK
```

## Files Modified/Created

- `core/users/models.py` — Added token field
- `core/users/routes/__init__.py` — Import password_reset module
- `core/users/routes/password_reset.py` — **NEW** Endpoints implementation
- `config/default.py` — Configuration keys
- `config/validate_config.py` — Validation rules
- `server/config/mails.py` — Email sending function
- `tests/test_password_reset.py` — **NEW** Test cases
- `DOCUMENTATION/PROJECT.md` — Updated with flows and security docs
- `README.md` — Updated with new endpoints

## Related Issues

Addresses: US-002 — Password Reset / Forgot Password Flow

## Commits

- `3dfeaca` — docs(US-002): add password reset endpoints and flows to documentation
- `2816219` — fix(US-002): correct url_for endpoint reference in password reset email
- `bc7a819` — feat(US-002): password reset/forgot password flow implementation
