### PR TITLE
feat(US-018): Environment-aware database migrations via APP_SETTINGS_MODULE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,5 +172,11 @@ requirements*.txt
 *.env
 
 migrations/*
+!migrations/env.py
+!migrations/alembic.ini
+!migrations/script.py.mako
+!migrations/README
+!migrations/versions/
+!migrations/versions/*.py
 
 .vscode

--- a/DOCUMENTATION/PROJECT.md
+++ b/DOCUMENTATION/PROJECT.md
@@ -1209,6 +1209,7 @@ gitgraph
 | Field | Detail |
 |---|---|
 | **Branch** | `feature/US-018-environment-aware-migrations` |
+| **PR** | [#14](https://github.com/mentally-gamez-soft/IAM-gateway/pull/14) |
 | **Status** | In Progress |
 | **Started** | 2026-02-20 |
 | **Trello** | [US-018](https://trello.com/c/1Hneaa4s) |

--- a/DOCUMENTATION/PROJECT.md
+++ b/DOCUMENTATION/PROJECT.md
@@ -1202,3 +1202,44 @@ gitgraph
 | TASK-005-3 | `core/users/routes/health.py`, `core/users/routes/__init__.py` | Applied `@csrf.exempt` decorator on both endpoints (imported from `core`); registered `health` module in blueprint imports |
 | TASK-005-4 | `Dockerfile`, `Docker/application/dev/docker-compose-dev.yaml`, `Docker/application/prod/docker-compose-prod.yaml` | Added `HEALTHCHECK` instruction to Dockerfile final stage using `wget --spider`; added `healthcheck` blocks to dev compose (app service) and prod compose (app service + nginx service) |
 | TASK-005-5 | `tests/test_health.py` *(new)* | 20-test suite across 2 classes: `HealthLivenessTestCase` (7 tests — status 200, JSON schema, `status`/`timestamp`/`version` fields, no auth, no CSRF, no DB calls) and `HealthReadinessTestCase` (13 tests — DB up → 200, DB fail → 503, `not_ready` status, `checks` dict keys, SMTP skipped, password_api skip on empty URL, no auth, CSRF exempt) |
+---
+
+### US-018 — Environment-Aware Database Migrations
+
+| Field | Detail |
+|---|---|
+| **Branch** | `feature/US-018-environment-aware-migrations` |
+| **Status** | In Progress |
+| **Started** | 2026-02-20 |
+| **Trello** | [US-018](https://trello.com/c/1Hneaa4s) |
+
+#### Problem solved
+
+`migrations/env.py` previously relied exclusively on Flask's `current_app`
+context (provided by Flask-Migrate) to obtain the database URL.  This was
+fragile in CI/CD pipelines or bare `alembic` invocations where the application
+context is not available.
+
+#### Solution
+
+`migrations/env.py` was redesigned to resolve the database URL through a
+two-step fallback:
+
+1. **Flask application context (primary)** — unchanged behavior for all
+   `flask db` commands.
+2. **`APP_SETTINGS_MODULE` import (fallback)** — when no app context is active,
+   the environment variable `APP_SETTINGS_MODULE` is read, the corresponding
+   config module is imported, and `SQLALCHEMY_DATABASE_URI` is extracted from it.
+
+> The DB password is masked in all log output.  A `RuntimeError` with a clear
+> message is raised when neither path is available.
+
+#### Changes implemented
+
+| Task | File(s) modified | Summary |
+|---|---|---|
+| TASK-018-1 | `migrations/env.py` | Full redesign: removed module-level `current_app` dependency; added `_get_url_from_settings_module()`, `_try_flask_context()`, `get_database_url()`, `_get_metadata()`, `_process_revision_directives()`; both runners updated for dual-path resolution |
+| TASK-018-3 | `README.md` | Replaced single-line migration commands with a full "Running Database Migrations" section documenting per-environment commands and standalone `alembic` invocation |
+| TASK-018-4 | `DOCUMENTATION/PROJECT.md` | This changelog entry |
+| US-018 | `DOCUMENTATION/USER_STORIES/user_story_018.md` *(new)* | User story definition |
+| TASK-018-1–4 | `DOCUMENTATION/TASKS/task_018_{1,2,3,4}.md` *(new)* | Task definitions |

--- a/DOCUMENTATION/TASKS/task_018_1.md
+++ b/DOCUMENTATION/TASKS/task_018_1.md
@@ -1,0 +1,49 @@
+```markdown
+# Task 018-1 — Modify `migrations/env.py` for Environment-Aware DB URL Resolution
+
+## Parent User Story
+
+[US-018 — Environment-Aware Database Migrations](../USER_STORIES/user_story_018.md)
+
+## Description
+
+Modify `migrations/env.py` to read the `APP_SETTINGS_MODULE` environment variable and dynamically import the corresponding configuration module to obtain `SQLALCHEMY_DATABASE_URI`. The existing Flask-Migrate / `current_app` path must be preserved as the primary path so that `flask db` commands continue to work unmodified.
+
+## Work to be Done
+
+1. Add a `get_database_url()` helper function that:
+   - Uses `current_app.extensions['migrate'].db` (existing path) when a Flask app context is active
+   - Falls back to importing `APP_SETTINGS_MODULE` and reading `SQLALCHEMY_DATABASE_URI` when no app context is available
+2. Update `run_migrations_offline()` to call `get_database_url()`
+3. Update `run_migrations_online()` to call `get_database_url()` and construct the engine when the Flask context is not available
+4. Add structured logging to indicate which environment and config module are being used
+5. Raise a clear `RuntimeError` if neither `current_app` context nor `APP_SETTINGS_MODULE` is available
+
+## Expected Outcome
+
+- `flask db upgrade` / `flask db migrate` continue to work exactly as before
+- `APP_SETTINGS_MODULE=config.local alembic upgrade head` works without a running Flask app
+- Environment switch requires only changing the `APP_SETTINGS_MODULE` env var, not editing files
+
+## Priority
+
+**High**
+
+## Acceptance Criteria
+
+- [ ] `flask db upgrade` succeeds in local environment (existing behaviour unchanged)
+- [ ] `APP_SETTINGS_MODULE=config.local flask db upgrade` uses the local DB URL
+- [ ] `APP_SETTINGS_MODULE=config.dev flask db upgrade` uses the dev DB URL
+- [ ] Running `alembic upgrade head` (standalone) with `APP_SETTINGS_MODULE` set picks the correct DB URL
+- [ ] A missing `APP_SETTINGS_MODULE` with no Flask context raises a `RuntimeError` with a clear message
+- [ ] The DB password is masked in log output
+- [ ] No regressions in the existing migration scripts
+
+## Status
+
+**0%**
+
+## Trello
+
+[TASK-018-1 — Modify migrations/env.py for environment-aware DB URL resolution](https://trello.com/c/EOdU2XHG)
+```

--- a/DOCUMENTATION/TASKS/task_018_2.md
+++ b/DOCUMENTATION/TASKS/task_018_2.md
@@ -1,0 +1,51 @@
+```markdown
+# Task 018-2 — Test Migration Scripts in Local and Dev Environments
+
+## Parent User Story
+
+[US-018 — Environment-Aware Database Migrations](../USER_STORIES/user_story_018.md)
+
+## Description
+
+Verify that the modified `migrations/env.py` works correctly in at least two different environments by running the migration commands with the appropriate `APP_SETTINGS_MODULE` value and confirming successful execution.
+
+## Work to be Done
+
+1. Test with `APP_SETTINGS_MODULE=config.local`:
+   - Run `flask db upgrade` and confirm it applies migrations to the local database
+   - Run `flask db migrate --message "test"` (dry-run) and confirm no errors
+   - Run standalone `alembic upgrade head` with `APP_SETTINGS_MODULE=config.local` set
+2. Test with `APP_SETTINGS_MODULE=config.dev`:
+   - Run `flask db upgrade` against the dev database
+   - Confirm the correct `DB_HOSTNAME` / `DB_NAME` are used
+3. Test error handling:
+   - Run without `APP_SETTINGS_MODULE` and without a Flask context → confirm clear `RuntimeError`
+   - Set `APP_SETTINGS_MODULE` to a non-existent module → confirm clear `ImportError`
+4. Confirm no regressions by running the full test suite after migrations
+
+## Expected Outcome
+
+- All migration commands succeed in local and dev environments
+- Error cases produce clear, actionable messages
+- Full test suite remains at 84/84 passing
+
+## Priority
+
+**High**
+
+## Acceptance Criteria
+
+- [ ] `flask db upgrade` succeeds in local environment with `APP_SETTINGS_MODULE=config.local`
+- [ ] `flask db upgrade` succeeds in dev environment with `APP_SETTINGS_MODULE=config.dev`
+- [ ] Standalone `alembic upgrade head` works with `APP_SETTINGS_MODULE` set
+- [ ] Error messages are clear when `APP_SETTINGS_MODULE` is missing or invalid
+- [ ] Full test suite passes after migrations: `uv run -m unittest tests.test_standard_routes`
+
+## Status
+
+**0%**
+
+## Trello
+
+[TASK-018-2 — Test migration scripts in local and dev environments](https://trello.com/c/RxbVj37x)
+```

--- a/DOCUMENTATION/TASKS/task_018_3.md
+++ b/DOCUMENTATION/TASKS/task_018_3.md
@@ -1,0 +1,46 @@
+```markdown
+# Task 018-3 — Update README.md with Per-Environment Migration Instructions
+
+## Parent User Story
+
+[US-018 — Environment-Aware Database Migrations](../USER_STORIES/user_story_018.md)
+
+## Description
+
+Update the `README.md` file to document how to run database migrations in each supported environment using the `APP_SETTINGS_MODULE` environment variable.
+
+## Work to be Done
+
+1. Add a dedicated **"Running Database Migrations"** section to `README.md`
+2. Document the `APP_SETTINGS_MODULE` variable and its accepted values
+3. Provide copy-paste commands for each environment:
+   - `config.local` — local development
+   - `config.dev` — containerized development
+   - `config.staging` — staging
+   - `config.prod` — production
+4. Document the standalone Alembic invocation alongside the `flask db` commands
+5. Add a note about the fallback behaviour (Flask context takes precedence)
+
+## Expected Outcome
+
+- Developers can quickly find and run the correct migration command for their target environment without consulting the source code
+
+## Priority
+
+**Medium**
+
+## Acceptance Criteria
+
+- [ ] `README.md` has a "Running Database Migrations" section
+- [ ] Each supported environment has an example migration command
+- [ ] Standalone `alembic` invocation is documented
+- [ ] The fallback behaviour is described
+
+## Status
+
+**0%**
+
+## Trello
+
+[TASK-018-3 — Update README.md with per-environment migration instructions](https://trello.com/c/JcxIGcYd)
+```

--- a/DOCUMENTATION/TASKS/task_018_4.md
+++ b/DOCUMENTATION/TASKS/task_018_4.md
@@ -1,0 +1,40 @@
+```markdown
+# Task 018-4 — Update DOCUMENTATION/PROJECT.md Changelog
+
+## Parent User Story
+
+[US-018 — Environment-Aware Database Migrations](../USER_STORIES/user_story_018.md)
+
+## Description
+
+Append a US-018 changelog entry to `DOCUMENTATION/PROJECT.md` describing the changes made to the migration infrastructure.
+
+## Work to be Done
+
+1. Add a US-018 entry to the changelog table in `DOCUMENTATION/PROJECT.md`
+2. Describe the problem solved and the approach taken
+3. List the files modified
+4. Note the backward-compatible fallback to the Flask-Migrate / `current_app` path
+
+## Expected Outcome
+
+- `DOCUMENTATION/PROJECT.md` reflects the migration infrastructure change with a dated changelog entry
+
+## Priority
+
+**Low**
+
+## Acceptance Criteria
+
+- [ ] US-018 entry exists in `DOCUMENTATION/PROJECT.md`
+- [ ] Entry references the modified `migrations/env.py` file
+- [ ] Entry describes the `APP_SETTINGS_MODULE` resolution strategy
+
+## Status
+
+**0%**
+
+## Trello
+
+[TASK-018-4 — Update DOCUMENTATION/PROJECT.md changelog](https://trello.com/c/MbjkTVKJ)
+```

--- a/DOCUMENTATION/USER_STORIES/user_story_018.md
+++ b/DOCUMENTATION/USER_STORIES/user_story_018.md
@@ -1,0 +1,57 @@
+```markdown
+# US-018 — Environment-Aware Database Migrations
+
+## Title
+
+Make Database Migration Scripts Dynamically Select the Correct Database Connection Based on Environment
+
+## User Story
+
+As a **developer**, I want the Alembic migration scripts to automatically read the `APP_SETTINGS_MODULE` environment variable and resolve the correct database connection string, so that I can run migrations in any environment without manually editing migration configuration files.
+
+## Description
+
+Currently, `migrations/env.py` relies exclusively on Flask's `current_app` context (provided by Flask-Migrate) to obtain the database connection URL. This works well when running `flask db upgrade` inside an active Flask application context, but becomes fragile in CI/CD pipelines, Docker entrypoints, or standalone Alembic runs where the application context may not be available or is difficult to bootstrap.
+
+The goal is to modify `migrations/env.py` so that it reads the `APP_SETTINGS_MODULE` environment variable, dynamically imports the matching configuration module (e.g., `config.local`, `config.dev`, `config.staging`, `config.prod`), and extracts `SQLALCHEMY_DATABASE_URI` from it. The existing Flask-Migrate / `current_app` path should remain as a fallback so that the normal `flask db` workflow is not broken.
+
+### Key Requirements
+
+- Read `APP_SETTINGS_MODULE` environment variable at migration startup
+- Dynamically import the configuration module indicated by `APP_SETTINGS_MODULE`
+- Extract `SQLALCHEMY_DATABASE_URI` from the imported module
+- Fall back to the existing Flask `current_app` / Flask-Migrate path if `APP_SETTINGS_MODULE` is not set
+- Log which environment and database URL (masked) is being used
+- No manual changes to migration scripts when switching environments
+- Compatible with `flask db upgrade`, `flask db migrate`, and standalone `alembic upgrade head`
+- Works in local, dev, staging, and production environments
+
+### Affected Components
+
+- `migrations/env.py` — core change: dynamic DB URL resolution
+- `README.md` — updated migration instructions per environment
+- `DOCUMENTATION/PROJECT.md` — changelog entry
+
+## Priority
+
+**High**
+
+## Estimated Cost
+
+**2 Story Points** (~1 day)
+
+## Related Tasks
+
+- [task_018_1.md](../TASKS/task_018_1.md) — Modify `migrations/env.py` for environment-aware DB URL resolution
+- [task_018_2.md](../TASKS/task_018_2.md) — Test migration scripts in local and dev environments
+- [task_018_3.md](../TASKS/task_018_3.md) — Update README.md with per-environment migration instructions
+- [task_018_4.md](../TASKS/task_018_4.md) — Update DOCUMENTATION/PROJECT.md changelog
+
+## Status
+
+**0%**
+
+## Trello
+
+[US-018 — Environment-Aware Database Migrations](https://trello.com/c/1Hneaa4s)
+```

--- a/README.md
+++ b/README.md
@@ -21,37 +21,47 @@ A set of tools is provided to help you to create, run and stop the docker contai
 ![Alt text](technology_stack_IAM-GW.svg)
 
 ## API Endpoints
+
+> **API Version**: All endpoints are now prefixed with `/api/v1/` (US-006).  
+> Legacy unversioned routes (e.g. `/login`) remain available until **2026-09-01** with deprecation headers.  
+> See [DOCUMENTATION/API_MIGRATION_GUIDE.md](DOCUMENTATION/API_MIGRATION_GUIDE.md) for the full migration guide.
+
 ### Sanity check
-    The check is located at home "/"
+    The check is located at "/api/v1/"
 
 ### Signup
-    The signup endpoint is located at "/signup"
+    The signup endpoint is located at "POST /api/v1/signup"
+    Legacy: POST /signup (deprecated — sunset 2026-09-01)
 
 ### Login
-    The login endpoint is located at "/login"
+    The login endpoint is located at "POST /api/v1/login"
+    Legacy: POST /login (deprecated — sunset 2026-09-01)
+    Response now includes access_token, refresh_token, token_type, expires_in
 
 ### Logout
-    The logout endpoint is located at "/logout"
+    The logout endpoint is located at "POST /api/v1/logout"
+    Legacy: POST /logout (deprecated — sunset 2026-09-01)
 
 ### Activation account
-    The activation account endpoint is located at "/confirm/<token>"
+    The activation account endpoint is located at "GET /api/v1/confirm/<token>"
+    Legacy: GET /confirm/<token> (deprecated — sunset 2026-09-01)
 
 ### Forgot password
-    The forgot password endpoint is located at "/forgot-password"
-    Request: POST /forgot-password with {"email": "user@example.com"}
+    The forgot password endpoint is located at "POST /api/v1/forgot-password"
+    Legacy: POST /forgot-password (deprecated — sunset 2026-09-01)
     Always returns 200 for security (prevents email enumeration)
     Rate limited to 3 requests per hour
 
 ### Reset password
-    The reset password endpoint is located at "/reset-password/<token>"
-    Request: POST /reset-password/<token> with {"new_password": "..."}
+    The reset password endpoint is located at "POST /api/v1/reset-password/<token>"
+    Legacy: POST /reset-password/<token> (deprecated — sunset 2026-09-01)
     Validates token expiration (30 minutes by default)
     Requires password strength validation
     Clears JWT session to force re-login
 
 ### Refresh Token
-    The token refresh endpoint is located at "/token/refresh"
-    Request: POST /token/refresh with refresh token in Authorization header or Body
+    The token refresh endpoint is located at "POST /api/v1/token/refresh"
+    Legacy: POST /token/refresh (deprecated — sunset 2026-09-01)
     Returns new access_token (15 min expiration) + refresh_token (7 days expiration)
     Supports token rotation with family tracking for security breach detection
     Replayed/revoked tokens trigger family-wide revocation (401 response)
@@ -137,14 +147,59 @@ Pass `X-Request-ID: <uuid>` in the request header to correlate log entries with 
 
     uv run -m flask --app application run --port 3456 --host 0.0.0.0
 
+    APP_SETTINGS_MODULE="config.local" \
+    FLASK_DEBUG=1 \
+    FLASK_APP="application" \
+    FLASK_ENV="development" \
+    uv run -m flask --app application run --port 3456 --host 0.0.0.0
+
 ### Executing the tests suit
     uv run -m unittest tests.test_standard_routes
     uv run -m unittest tests.test_health
 
-### Executing database migrations:
+### Running Database Migrations
+
+The migration runner (`migrations/env.py`) automatically selects the correct
+database connection based on the `APP_SETTINGS_MODULE` environment variable.
+The Flask application context takes priority; if it is not available (e.g. in a
+CI/CD pipeline or a bare Alembic invocation) the config module is imported
+directly to resolve `SQLALCHEMY_DATABASE_URI`.
+
+**Initialise migration structure (first time only)**
+
     flask --app application db init
-    flask --app application db migrate -m "initial migrations"
-    flask --app application db upgrade
+
+**Generate a new migration script (autogenerate)**
+
+    # local
+    APP_SETTINGS_MODULE="config.local" uv run -m flask --app application db migrate -m "description"
+
+    # dev
+    APP_SETTINGS_MODULE="config.dev"   uv run -m flask --app application db migrate -m "description"
+
+**Apply pending migrations**
+
+    # local
+    APP_SETTINGS_MODULE="config.local"   uv run -m flask --app application db upgrade
+
+    # dev
+    APP_SETTINGS_MODULE="config.dev"     uv run -m flask --app application db upgrade
+
+    # staging
+    APP_SETTINGS_MODULE="config.staging" uv run -m flask --app application db upgrade
+
+    # production
+    APP_SETTINGS_MODULE="config.prod"    uv run -m flask --app application db upgrade
+
+**Standalone Alembic (no Flask app required)**
+
+    APP_SETTINGS_MODULE="config.local" uv run -m alembic upgrade head
+    APP_SETTINGS_MODULE="config.dev"   uv run -m alembic upgrade head
+
+> **Note:** `APP_SETTINGS_MODULE` must be set, and all environment variables
+> referenced by the selected config module (e.g. `SQLALCHEMY_DATABASE_URI`)
+> must be available (loaded from the corresponding `.env.*` file or set
+> directly in the shell).
 
 ## Docker Images
 ### Create an image

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,226 @@
+import importlib
+import logging
+import os
+import sys
+from logging.config import fileConfig
+from urllib.parse import urlparse
+
+from alembic import context
+
+# ---------------------------------------------------------------------------
+# Alembic config object — provides access to values in alembic.ini
+# ---------------------------------------------------------------------------
+config = context.config
+
+# Set up loggers from alembic.ini
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+logger = logging.getLogger("alembic.env")
+
+# Ensure the project root is importable (needed for standalone alembic runs)
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mask_db_url(url: str) -> str:
+    """Return the DB URL with the password replaced by ***."""
+    parsed = urlparse(url)
+    if parsed.password:
+        return url.replace(parsed.password, "***")
+    return url
+
+
+def _get_url_from_settings_module() -> str:
+    """Load SQLALCHEMY_DATABASE_URI from the APP_SETTINGS_MODULE config module.
+
+    Raises:
+        RuntimeError: when APP_SETTINGS_MODULE is not set or the module does
+            not expose SQLALCHEMY_DATABASE_URI.
+    """
+    settings_module = os.environ.get("APP_SETTINGS_MODULE")
+    if not settings_module:
+        raise RuntimeError(
+            "No Flask application context is available and the "
+            "APP_SETTINGS_MODULE environment variable is not set.\n"
+            "Set APP_SETTINGS_MODULE to one of: "
+            "config.local | config.dev | config.staging | config.prod"
+        )
+
+    try:
+        module = importlib.import_module(settings_module)
+    except ImportError as exc:
+        raise RuntimeError(
+            f"Failed to import configuration module '{settings_module}': {exc}"
+        ) from exc
+
+    db_url = getattr(module, "SQLALCHEMY_DATABASE_URI", None)
+    if not db_url:
+        raise RuntimeError(
+            f"SQLALCHEMY_DATABASE_URI is not defined (or is empty) in "
+            f"'{settings_module}'. "
+            "Ensure the required environment variables are loaded for that "
+            "environment (e.g. via the corresponding .env file)."
+        )
+
+    logger.info(
+        "Migration target from '%s': %s", settings_module, _mask_db_url(db_url)
+    )
+    return db_url
+
+
+def _try_flask_context():
+    """Return (engine, url, db, migrate_conf_args) from Flask context.
+
+    Returns a tuple of four Nones when no application context is active.
+    """
+    try:
+        from flask import current_app  # noqa: PLC0415
+
+        db = current_app.extensions["migrate"].db
+        try:
+            engine = db.get_engine()
+        except (TypeError, AttributeError):
+            engine = db.engine
+
+        try:
+            url = engine.url.render_as_string(hide_password=False).replace(
+                "%", "%%"
+            )
+        except AttributeError:
+            url = str(engine.url).replace("%", "%%")
+
+        conf_args = current_app.extensions["migrate"].configure_args
+        logger.info(
+            "Migration target from Flask context: %s", _mask_db_url(url)
+        )
+        return engine, url, db, conf_args
+
+    except RuntimeError:
+        # No active Flask application context
+        return None, None, None, None
+
+
+def get_database_url() -> str:
+    """Return the database URL for migrations.
+
+    Resolution order:
+    1. Flask application context / Flask-Migrate  (normal ``flask db`` usage)
+    2. APP_SETTINGS_MODULE environment variable   (standalone Alembic / CI)
+    """
+    _, url, _, _ = _try_flask_context()
+    if url:
+        return url
+    return _get_url_from_settings_module()
+
+
+def _get_metadata():
+    """Return the SQLAlchemy metadata object for autogenerate support."""
+    _, _, db, _ = _try_flask_context()
+    if db is not None:
+        if hasattr(db, "metadatas"):
+            return db.metadatas[None]
+        return db.metadata
+
+    # No Flask context — import db + models directly so the metadata is
+    # populated before Alembic inspects it.
+    import core.users.models  # noqa: F401, PLC0415
+    from core import db as core_db  # noqa: PLC0415
+
+    return core_db.metadata
+
+
+def _process_revision_directives(context, revision, directives):
+    """Skip empty auto-generated migrations.
+
+    Reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
+    """
+    if getattr(config.cmd_opts, "autogenerate", False):
+        script = directives[0]
+        if script.upgrade_ops.is_empty():
+            directives[:] = []
+            logger.info("No changes in schema detected.")
+
+
+# ---------------------------------------------------------------------------
+# Migration runners
+# ---------------------------------------------------------------------------
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    Configures the context with just a URL and not an Engine.  Skipping
+    Engine creation means no DBAPI connection is required.
+
+    Calls to context.execute() emit the given string to the script output.
+    """
+    url = get_database_url()
+    context.configure(
+        url=url,
+        target_metadata=_get_metadata(),
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    Creates an Engine and associates a connection with the context.
+    When a Flask application context is active the existing Flask-Migrate
+    engine is reused; otherwise a fresh engine is built from the URL
+    resolved via APP_SETTINGS_MODULE.
+    """
+    engine, url, _, conf_args = _try_flask_context()
+
+    if engine is not None:
+        # ── Flask context path (normal `flask db` usage) ─────────────────
+        if conf_args is None:
+            conf_args = {}
+        if conf_args.get("process_revision_directives") is None:
+            conf_args["process_revision_directives"] = (
+                _process_revision_directives
+            )
+
+        with engine.connect() as connection:
+            context.configure(
+                connection=connection,
+                target_metadata=_get_metadata(),
+                **conf_args,
+            )
+            with context.begin_transaction():
+                context.run_migrations()
+    else:
+        # ── Standalone / CI path (APP_SETTINGS_MODULE) ────────────────────
+        from sqlalchemy import engine_from_config, pool  # noqa: PLC0415
+
+        db_url = _get_url_from_settings_module()
+        connectable = engine_from_config(
+            {"sqlalchemy.url": db_url},
+            prefix="sqlalchemy.",
+            poolclass=pool.NullPool,
+        )
+
+        with connectable.connect() as connection:
+            context.configure(
+                connection=connection,
+                target_metadata=_get_metadata(),
+                process_revision_directives=_process_revision_directives,
+            )
+            with context.begin_transaction():
+                context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()


### PR DESCRIPTION
## Summary

Rewrites `migrations/env.py` so Alembic can resolve the database URL through two independent paths, making standalone CI/CD and Docker entrypoint runs reliable.

## Problem

`migrations/env.py` previously depended exclusively on Flask-Migrate's `current_app` context.  Any invocation outside a running Flask application (bare `alembic upgrade head`, CI pipelines, Docker entrypoints) raised:

```
RuntimeError: Working outside of application context
```

## Solution

Two-step URL resolution with a clear fallback:

1. **Flask application context (primary)** — all `flask db` commands continue to work unchanged.
2. **`APP_SETTINGS_MODULE` import (fallback)** — when no app context is active, the config module is imported dynamically and `SQLALCHEMY_DATABASE_URI` is read from it.

A `RuntimeError` with an actionable message is raised when neither path is available.

## Changes

| File | Change |
|---|---|
| `migrations/env.py` | Full rewrite: lazy Flask context detection, `APP_SETTINGS_MODULE` fallback, password masking in logs |
| `.gitignore` | Added negation exceptions so `migrations/env.py` and Alembic framework files are tracked |
| `README.md` | Full per-environment migration instructions (local / dev / staging / prod + standalone alembic) |
| `DOCUMENTATION/USER_STORIES/user_story_018.md` | New user story |
| `DOCUMENTATION/TASKS/task_018_{1-4}.md` | New task files |
| `DOCUMENTATION/PROJECT.md` | US-018 changelog entry |

## Testing

```bash
APP_SETTINGS_MODULE=config.local uv run -m flask --app application db current   # ✅
APP_SETTINGS_MODULE=config.local uv run -m flask --app application db upgrade   # ✅
```

## Trello
- [US-018](https://trello.com/c/1Hneaa4s)
- [TASK-018-1](https://trello.com/c/EOdU2XHG)
- [TASK-018-2](https://trello.com/c/RxbVj37x)
- [TASK-018-3](https://trello.com/c/JcxIGcYd)
- [TASK-018-4](https://trello.com/c/MbjkTVKJ)