### PR TITLE
fix: unit test fixes for US-003 access_token rename and JWT payload compatibility

### DIFF
--- a/core/auth/auth_guard.py
+++ b/core/auth/auth_guard.py
@@ -53,8 +53,10 @@ def authorization_guard(f, role=None):
 
         # Authentication gate
         try:
-            jwt = json["data"]["jwt"]
+            jwt = json["data"].get("jwt") or json["data"].get("access_token")
             user = json["data"]["user"]
+            if not jwt:
+                raise KeyError("No token provided")
         except Exception as e:
             return (
                 jsonify(

--- a/core/auth/jwt/jwt_handler.py
+++ b/core/auth/jwt/jwt_handler.py
@@ -10,6 +10,7 @@ from flask import request
 from config.default import (
     JWT_ACCESS_TOKEN_LIFETIME,
     JWT_ALG,
+    JWT_ENCODING_PARAM_1,
     JWT_REFRESH_TOKEN_LIFETIME,
     SECRET_KEY,
 )
@@ -141,7 +142,13 @@ def generate_token_pair(user_id: str, payload_data: dict) -> dict:
     from core.users.models import RefreshToken
 
     # Generate access token with short lifetime
-    access_payload = {"sub": str(user_id), **payload_data}
+    access_payload = {
+        "sub": str(user_id),
+        JWT_ENCODING_PARAM_1: str(
+            user_id
+        ),  # backward compat with downstream decoders
+        **payload_data,
+    }
     access_token = generate_jwt(
         payload=access_payload, lifetime=JWT_ACCESS_TOKEN_LIFETIME
     )

--- a/core/auth/payload_validator.py
+++ b/core/auth/payload_validator.py
@@ -33,7 +33,9 @@ def validate_generic_payload(f):
     def decorated_function(*args, **kwargs):
         json = request.get_json()
         try:
-            jwt = json["data"]["jwt"]
+            jwt = json["data"].get("jwt") or json["data"].get("access_token")
+            if not jwt:
+                raise KeyError("No token provided")
         except:
             return (
                 jsonify(

--- a/core/users/routes/logout.py
+++ b/core/users/routes/logout.py
@@ -39,7 +39,7 @@ def logout():
         Response: the response to the index page.
     """
     json = request.get_json()
-    jwt = json["data"]["jwt"]
+    jwt = json["data"].get("jwt") or json["data"].get("access_token")
     jwt_decoded = decode_jwt(jwt)
     user = GwUser.get_by_id(jwt_decoded[JWT_ENCODING_PARAM_1])
     user.jwt_session_id = None

--- a/core/users/routes/roles.py
+++ b/core/users/routes/roles.py
@@ -67,7 +67,7 @@ def add_role():
     )
     json = request.get_json()
 
-    jwt = json["data"]["jwt"]
+    jwt = json["data"].get("jwt") or json["data"].get("access_token")
     role = json["data"]["role"]
 
     jwt_decoded = decode_jwt(jwt)

--- a/core/users/routes/sanity_check.py
+++ b/core/users/routes/sanity_check.py
@@ -64,11 +64,13 @@ def protected():
             {
                 "data": {
                     "user": json["data"]["user"],
-                    "jwt": json["data"]["jwt"],
+                    "jwt": (
+                        json["data"].get("jwt")
+                        or json["data"].get("access_token")
+                    ),
                 },
-                "message": (
-                    "Welcome to {} service. (You're using the version {})"
-                    .format(API_TITLE, API_VERSION)
+                "message": "Welcome to {} service. (You're using the version {})".format(
+                    API_TITLE, API_VERSION
                 ),
                 "status": __RESPONSE_STATUS_200,
             }
@@ -99,11 +101,13 @@ def protected_with_role():
             {
                 "data": {
                     "user": json["data"]["user"],
-                    "jwt": json["data"]["jwt"],
+                    "jwt": (
+                        json["data"].get("jwt")
+                        or json["data"].get("access_token")
+                    ),
                 },
-                "message": (
-                    "Welcome to {} service. (You're using the version {})"
-                    .format(API_TITLE, API_VERSION)
+                "message": "Welcome to {} service. (You're using the version {})".format(
+                    API_TITLE, API_VERSION
                 ),
                 "status": __RESPONSE_STATUS_200,
             }

--- a/core/users/routes/token.py
+++ b/core/users/routes/token.py
@@ -179,8 +179,8 @@ def refresh_token():
         # Generate new token pair with same family ID for tracking
         from datetime import datetime, timedelta
 
-        from application import db
         from config.default import JWT_REFRESH_TOKEN_LIFETIME
+        from core import db
         from core.auth.jwt.jwt_handler import (
             generate_jwt,
             generate_refresh_token,
@@ -193,14 +193,12 @@ def refresh_token():
 
         # Create new token record with same family ID
         new_token_record = RefreshToken(
-            token=new_refresh_token_hash,
             user_id=user.id,
-            family_id=refresh_token_record.family_id,  # Keep same family
-            created_on=datetime.utcnow(),
             expires_on=datetime.utcnow()
             + timedelta(minutes=JWT_REFRESH_TOKEN_LIFETIME),
-            revoked=False,
+            family_id=refresh_token_record.family_id,  # Keep same family
         )
+        new_token_record.token = new_refresh_token_hash
 
         db.session.add(new_token_record)
         db.session.commit()

--- a/tests/test_refresh_token.py
+++ b/tests/test_refresh_token.py
@@ -1,496 +1,430 @@
 """Test suite for JWT Refresh Token mechanism (US-003)."""
 
-import json
+import unittest
 import uuid
 from datetime import datetime, timedelta
 
-import pytest
-
+from core import db
 from core.auth.jwt.jwt_handler import (
     decode_jwt,
     generate_refresh_token,
     generate_token_pair,
 )
-from core.common.error_codes import (
-    __RESPONSE_STATUS_200,
-    __RESPONSE_STATUS_401,
-)
 from core.users.models import GwUser, RefreshToken
 
-
-@pytest.fixture
-def test_user(app):
-    """Create a test user for token tests."""
-    with app.app_context():
-        user = GwUser(
-            id=uuid.uuid4(),
-            username=f"testuser_{uuid.uuid4().hex[:8]}",
-            email=f"test_{uuid.uuid4().hex[:8]}@example.com",
-            password="TestPassword123!",
-            created_on=datetime.utcnow(),
-        )
-        user.save()
-        yield user
-        try:
-            user.delete()
-        except Exception:
-            pass
+from . import BaseTestClass
 
 
-@pytest.fixture
-def client(app):
-    """Create a test client."""
-    return app.test_client()
+class _TokenTestMixin:
+    """Mixin that creates a dedicated test user in setUp."""
+
+    def _create_token_test_user(self):
+        """Create a fresh user for token tests and store its id/email."""
+        with self.app.app_context():
+            user = GwUser(
+                f"tokenuser_{uuid.uuid4().hex[:8]}",
+                f"tokenuser_{uuid.uuid4().hex[:8]}@example.com",
+            )
+            user.set_password("TestPassword123!")
+            user.active = True
+            user.save()
+            self.test_user_id = user.id
+            self.test_user_email = user.email
 
 
-class TestRefreshTokenModel:
+class TestRefreshTokenModel(_TokenTestMixin, BaseTestClass):
     """Test RefreshToken model functionality."""
+
+    def setUp(self):
+        super().setUp()
+        self._create_token_test_user()
+
+    # ------------------------------------------------------------------
+    # Hash tests (no app context needed)
+    # ------------------------------------------------------------------
 
     def test_hash_token_generates_consistent_hash(self):
         """Test that hashing produces consistent results."""
         token = "test_token_123"
         hash1 = RefreshToken.hash_token(token)
         hash2 = RefreshToken.hash_token(token)
-        assert hash1 == hash2
+        self.assertEqual(hash1, hash2)
 
     def test_hash_token_different_for_different_tokens(self):
         """Test that different tokens produce different hashes."""
-        token1 = "token1"
-        token2 = "token2"
-        hash1 = RefreshToken.hash_token(token1)
-        hash2 = RefreshToken.hash_token(token2)
-        assert hash1 != hash2
+        hash1 = RefreshToken.hash_token("token1")
+        hash2 = RefreshToken.hash_token("token2")
+        self.assertNotEqual(hash1, hash2)
 
-    def test_refresh_token_is_valid_when_not_expired_or_revoked(
-        self, app, test_user
-    ):
+    # ------------------------------------------------------------------
+    # Validity tests
+    # ------------------------------------------------------------------
+
+    def test_refresh_token_is_valid_when_not_expired_or_revoked(self):
         """Test is_valid() returns True for valid tokens."""
-        with app.app_context():
-            token_string = generate_refresh_token()
-            token_hash = RefreshToken.hash_token(token_string)
-
-            refresh_token = RefreshToken(
-                token=token_hash,
-                user_id=test_user.id,
-                family_id=uuid.uuid4(),
-                created_on=datetime.utcnow(),
+        with self.app.app_context():
+            token_hash = RefreshToken.hash_token(generate_refresh_token())
+            rt = RefreshToken(
+                user_id=self.test_user_id,
                 expires_on=datetime.utcnow() + timedelta(days=7),
-                revoked=False,
+                family_id=uuid.uuid4(),
             )
-            refresh_token.save()
+            rt.token = token_hash
+            rt.save()
+            self.assertTrue(rt.is_valid())
 
-            assert refresh_token.is_valid() is True
-
-    def test_refresh_token_is_not_valid_when_expired(self, app, test_user):
+    def test_refresh_token_is_not_valid_when_expired(self):
         """Test is_valid() returns False for expired tokens."""
-        with app.app_context():
-            token_string = generate_refresh_token()
-            token_hash = RefreshToken.hash_token(token_string)
-
-            refresh_token = RefreshToken(
-                token=token_hash,
-                user_id=test_user.id,
-                family_id=uuid.uuid4(),
-                created_on=datetime.utcnow(),
+        with self.app.app_context():
+            token_hash = RefreshToken.hash_token(generate_refresh_token())
+            rt = RefreshToken(
+                user_id=self.test_user_id,
                 expires_on=datetime.utcnow() - timedelta(hours=1),
-                revoked=False,
+                family_id=uuid.uuid4(),
             )
-            refresh_token.save()
+            rt.token = token_hash
+            rt.save()
+            self.assertFalse(rt.is_valid())
 
-            assert refresh_token.is_valid() is False
-
-    def test_refresh_token_is_not_valid_when_revoked(self, app, test_user):
+    def test_refresh_token_is_not_valid_when_revoked(self):
         """Test is_valid() returns False for revoked tokens."""
-        with app.app_context():
-            token_string = generate_refresh_token()
-            token_hash = RefreshToken.hash_token(token_string)
-
-            refresh_token = RefreshToken(
-                token=token_hash,
-                user_id=test_user.id,
-                family_id=uuid.uuid4(),
-                created_on=datetime.utcnow(),
+        with self.app.app_context():
+            token_hash = RefreshToken.hash_token(generate_refresh_token())
+            rt = RefreshToken(
+                user_id=self.test_user_id,
                 expires_on=datetime.utcnow() + timedelta(days=7),
-                revoked=True,
+                family_id=uuid.uuid4(),
             )
-            refresh_token.save()
+            rt.token = token_hash
+            rt.revoked = True
+            rt.save()
+            self.assertFalse(rt.is_valid())
 
-            assert refresh_token.is_valid() is False
-
-    def test_is_expired_returns_true_for_expired_token(self, app, test_user):
+    def test_is_expired_returns_true_for_expired_token(self):
         """Test is_expired() for tokens past expiration."""
-        with app.app_context():
-            token_string = generate_refresh_token()
-            token_hash = RefreshToken.hash_token(token_string)
-
-            refresh_token = RefreshToken(
-                token=token_hash,
-                user_id=test_user.id,
-                family_id=uuid.uuid4(),
-                created_on=datetime.utcnow(),
+        with self.app.app_context():
+            token_hash = RefreshToken.hash_token(generate_refresh_token())
+            rt = RefreshToken(
+                user_id=self.test_user_id,
                 expires_on=datetime.utcnow() - timedelta(hours=1),
-                revoked=False,
+                family_id=uuid.uuid4(),
             )
-            refresh_token.save()
+            rt.token = token_hash
+            rt.save()
+            self.assertTrue(rt.is_expired())
 
-            assert refresh_token.is_expired() is True
+    # ------------------------------------------------------------------
+    # Revocation tests
+    # ------------------------------------------------------------------
 
-    def test_revoke_sets_revoked_flag_and_timestamp(self, app, test_user):
+    def test_revoke_sets_revoked_flag_and_timestamp(self):
         """Test that revoke() sets revoked flag and timestamp."""
-        with app.app_context():
-            token_string = generate_refresh_token()
-            token_hash = RefreshToken.hash_token(token_string)
-
-            refresh_token = RefreshToken(
-                token=token_hash,
-                user_id=test_user.id,
-                family_id=uuid.uuid4(),
-                created_on=datetime.utcnow(),
+        with self.app.app_context():
+            token_hash = RefreshToken.hash_token(generate_refresh_token())
+            rt = RefreshToken(
+                user_id=self.test_user_id,
                 expires_on=datetime.utcnow() + timedelta(days=7),
-                revoked=False,
-            )
-            refresh_token.save()
-
-            refresh_token.revoke()
-            assert refresh_token.revoked is True
-            assert refresh_token.revoked_on is not None
-
-    def test_get_by_token_finds_token(self, app, test_user):
-        """Test get_by_token() finds stored tokens."""
-        with app.app_context():
-            token_string = generate_refresh_token()
-            token_hash = RefreshToken.hash_token(token_string)
-
-            refresh_token = RefreshToken(
-                token=token_hash,
-                user_id=test_user.id,
                 family_id=uuid.uuid4(),
-                created_on=datetime.utcnow(),
-                expires_on=datetime.utcnow() + timedelta(days=7),
             )
-            refresh_token.save()
+            rt.token = token_hash
+            rt.save()
+            rt.revoke()
+            self.assertTrue(rt.revoked)
+            self.assertIsNotNone(rt.revoked_on)
 
-            found = RefreshToken.get_by_token(token_hash)
-            assert found is not None
-            assert found.token == token_hash
-
-    def test_get_by_token_returns_none_for_unknown_token(self, app):
-        """Test get_by_token() returns None for non-existent tokens."""
-        with app.app_context():
-            unknown_hash = RefreshToken.hash_token("unknown_token")
-            found = RefreshToken.get_by_token(unknown_hash)
-            assert found is None
-
-    def test_revoke_all_for_user_revokes_all_tokens(self, app, test_user):
+    def test_revoke_all_for_user_revokes_all_tokens(self):
         """Test revoke_all_for_user() revokes all user tokens."""
-        with app.app_context():
-            # Create multiple tokens for user
+        with self.app.app_context():
             for _ in range(3):
-                token_string = generate_refresh_token()
-                token_hash = RefreshToken.hash_token(token_string)
-                refresh_token = RefreshToken(
-                    token=token_hash,
-                    user_id=test_user.id,
-                    family_id=uuid.uuid4(),
-                    created_on=datetime.utcnow(),
+                token_hash = RefreshToken.hash_token(generate_refresh_token())
+                rt = RefreshToken(
+                    user_id=self.test_user_id,
                     expires_on=datetime.utcnow() + timedelta(days=7),
-                    revoked=False,
+                    family_id=uuid.uuid4(),
                 )
-                refresh_token.save()
+                rt.token = token_hash
+                rt.save()
 
-            # Revoke all
-            RefreshToken.revoke_all_for_user(test_user.id)
-
-            # Verify all revoked
-            from application import db
+            RefreshToken.revoke_all_for_user(self.test_user_id)
 
             tokens = (
                 db.session.query(RefreshToken)
-                .filter_by(user_id=test_user.id)
+                .filter_by(user_id=self.test_user_id)
                 .all()
             )
-            assert all(t.revoked for t in tokens)
+            self.assertTrue(all(t.revoked for t in tokens))
 
-    def test_revoke_family_revokes_all_tokens_in_family(self, app, test_user):
+    def test_revoke_family_revokes_all_tokens_in_family(self):
         """Test revoke_family() revokes all tokens in token family."""
-        with app.app_context():
+        with self.app.app_context():
             family_id = uuid.uuid4()
-
-            # Create multiple tokens in same family
             for _ in range(3):
-                token_string = generate_refresh_token()
-                token_hash = RefreshToken.hash_token(token_string)
-                refresh_token = RefreshToken(
-                    token=token_hash,
-                    user_id=test_user.id,
-                    family_id=family_id,
-                    created_on=datetime.utcnow(),
+                token_hash = RefreshToken.hash_token(generate_refresh_token())
+                rt = RefreshToken(
+                    user_id=self.test_user_id,
                     expires_on=datetime.utcnow() + timedelta(days=7),
-                    revoked=False,
+                    family_id=family_id,
                 )
-                refresh_token.save()
+                rt.token = token_hash
+                rt.save()
 
-            # Revoke family
             RefreshToken.revoke_family(family_id)
-
-            # Verify all in family revoked
-            from application import db
 
             tokens = (
                 db.session.query(RefreshToken)
                 .filter_by(family_id=family_id)
                 .all()
             )
-            assert all(t.revoked for t in tokens)
+            self.assertTrue(all(t.revoked for t in tokens))
+
+    # ------------------------------------------------------------------
+    # Lookup tests
+    # ------------------------------------------------------------------
+
+    def test_get_by_token_finds_token(self):
+        """Test get_by_token() finds stored tokens."""
+        with self.app.app_context():
+            token_string = generate_refresh_token()
+            token_hash = RefreshToken.hash_token(token_string)
+            rt = RefreshToken(
+                user_id=self.test_user_id,
+                expires_on=datetime.utcnow() + timedelta(days=7),
+                family_id=uuid.uuid4(),
+            )
+            rt.token = token_hash
+            rt.save()
+
+            found = RefreshToken.get_by_token(token_hash)
+            self.assertIsNotNone(found)
+            self.assertEqual(found.token, token_hash)
+
+    def test_get_by_token_returns_none_for_unknown_token(self):
+        """Test get_by_token() returns None for non-existent tokens."""
+        with self.app.app_context():
+            unknown_hash = RefreshToken.hash_token("unknown_token")
+            self.assertIsNone(RefreshToken.get_by_token(unknown_hash))
 
 
-class TestTokenGeneration:
+class TestTokenGeneration(_TokenTestMixin, BaseTestClass):
     """Test token generation functionality."""
 
+    def setUp(self):
+        super().setUp()
+        self._create_token_test_user()
+
     def test_generate_refresh_token_returns_string(self):
-        """Test generate_refresh_token() returns a string."""
+        """Test generate_refresh_token() returns a non-empty string."""
         token = generate_refresh_token()
-        assert isinstance(token, str)
-        assert len(token) > 0
+        self.assertIsInstance(token, str)
+        self.assertGreater(len(token), 0)
 
     def test_generate_refresh_token_creates_unique_tokens(self):
-        """Test that consecutive generations create different tokens."""
-        token1 = generate_refresh_token()
-        token2 = generate_refresh_token()
-        assert token1 != token2
+        """Test that consecutive generations produce different tokens."""
+        self.assertNotEqual(generate_refresh_token(), generate_refresh_token())
 
-    def test_generate_token_pair_returns_all_required_fields(
-        self, app, test_user
-    ):
+    def test_generate_token_pair_returns_all_required_fields(self):
         """Test generate_token_pair() returns required fields."""
-        with app.app_context():
+        with self.app.app_context():
             pair = generate_token_pair(
-                user_id=test_user.id,
+                user_id=self.test_user_id,
                 payload_data={"test": "data"},
             )
+        self.assertIn("access_token", pair)
+        self.assertIn("refresh_token", pair)
+        self.assertIn("token_type", pair)
+        self.assertIn("expires_in", pair)
+        self.assertEqual(pair["token_type"], "Bearer")
 
-            assert "access_token" in pair
-            assert "refresh_token" in pair
-            assert "token_type" in pair
-            assert "expires_in" in pair
-            assert pair["token_type"] == "Bearer"
-
-    def test_generate_token_pair_stores_refresh_token(self, app, test_user):
-        """Test that generate_token_pair() stores refresh token in DB."""
-        with app.app_context():
+    def test_generate_token_pair_stores_refresh_token(self):
+        """Test that generate_token_pair() persists the refresh token in DB."""
+        with self.app.app_context():
             pair = generate_token_pair(
-                user_id=test_user.id,
+                user_id=self.test_user_id,
                 payload_data={"test": "data"},
             )
-
-            # Try to retrieve the stored token
             token_hash = RefreshToken.hash_token(pair["refresh_token"])
             stored = RefreshToken.get_by_token(token_hash)
+            self.assertIsNotNone(stored)
+            self.assertEqual(stored.user_id, self.test_user_id)
+            self.assertFalse(stored.revoked)
 
-            assert stored is not None
-            assert stored.user_id == test_user.id
-            assert stored.revoked is False
-
-    def test_access_token_is_valid_jwt(self, app, test_user):
-        """Test that access token is a valid JWT."""
-        with app.app_context():
+    def test_access_token_is_valid_jwt(self):
+        """Test that the access token is a valid decodable JWT."""
+        with self.app.app_context():
             pair = generate_token_pair(
-                user_id=test_user.id,
-                payload_data={"email": test_user.email},
+                user_id=self.test_user_id,
+                payload_data={"email": self.test_user_email},
             )
-
-            # Try to decode the access token
             decoded = decode_jwt(pair["access_token"])
-            assert decoded is not None
-            assert decoded["sub"] == str(test_user.id)
+            self.assertIsNotNone(decoded)
+            self.assertEqual(decoded["sub"], str(self.test_user_id))
 
 
-class TestTokenRefreshEndpoint:
+class TestTokenRefreshEndpoint(_TokenTestMixin, BaseTestClass):
     """Test the /token/refresh endpoint."""
 
-    def test_refresh_token_endpoint_exists(self, client):
-        """Test that the refresh token endpoint exists."""
-        response = client.post(
+    def setUp(self):
+        super().setUp()
+        self._create_token_test_user()
+
+    def test_refresh_token_endpoint_exists(self):
+        """Test that the refresh token endpoint is registered (not 404)."""
+        response = self.client.post(
             "/token/refresh",
             json={"refresh_token": "test"},
         )
-        # Should not be 404 (endpoint exists)
-        assert response.status_code != 404
+        self.assertNotEqual(response.status_code, 404)
 
-    def test_refresh_token_requires_token_in_request(self, client):
-        """Test that endpoint rejects requests without refresh token."""
-        response = client.post(
-            "/token/refresh",
-            json={},
-        )
-        assert response.status_code == 400
+    def test_refresh_token_requires_token_in_request(self):
+        """Test that endpoint rejects requests without a refresh token."""
+        response = self.client.post("/token/refresh", json={})
+        self.assertEqual(response.status_code, 400)
 
-    def test_refresh_token_rejects_invalid_token(self, client):
+    def test_refresh_token_rejects_invalid_token(self):
         """Test that endpoint rejects invalid/unknown tokens."""
-        response = client.post(
+        response = self.client.post(
             "/token/refresh",
             json={"refresh_token": "invalid_token_xyz"},
         )
-        assert response.status_code == 401
+        self.assertEqual(response.status_code, 401)
 
-    def test_refresh_token_rejects_expired_token(self, app, client, test_user):
+    def test_refresh_token_rejects_expired_token(self):
         """Test that endpoint rejects expired tokens."""
-        with app.app_context():
-            # Create expired token
+        with self.app.app_context():
             token_string = generate_refresh_token()
             token_hash = RefreshToken.hash_token(token_string)
-
-            refresh_token = RefreshToken(
-                token=token_hash,
-                user_id=test_user.id,
-                family_id=uuid.uuid4(),
-                created_on=datetime.utcnow(),
+            rt = RefreshToken(
+                user_id=self.test_user_id,
                 expires_on=datetime.utcnow() - timedelta(hours=1),
-                revoked=False,
-            )
-            refresh_token.save()
-
-        response = client.post(
-            "/token/refresh",
-            json={"refresh_token": token_string},
-        )
-        assert response.status_code == 401
-        assert "expired" in response.json["message"].lower()
-
-    def test_refresh_token_rejects_revoked_token(self, app, client, test_user):
-        """Test that endpoint rejects revoked tokens."""
-        with app.app_context():
-            # Create revoked token
-            token_string = generate_refresh_token()
-            token_hash = RefreshToken.hash_token(token_string)
-
-            refresh_token = RefreshToken(
-                token=token_hash,
-                user_id=test_user.id,
                 family_id=uuid.uuid4(),
-                created_on=datetime.utcnow(),
-                expires_on=datetime.utcnow() + timedelta(days=7),
-                revoked=True,
             )
-            refresh_token.save()
+            rt.token = token_hash
+            rt.save()
 
-        response = client.post(
+        response = self.client.post(
             "/token/refresh",
             json={"refresh_token": token_string},
         )
-        assert response.status_code == 401
-        assert "revoked" in response.json["message"].lower()
+        self.assertEqual(response.status_code, 401)
+        self.assertIn("expired", response.json["message"].lower())
 
-    def test_refresh_token_detects_reuse(self, app, client, test_user):
-        """Test that endpoint detects and blocks token reuse (security)."""
-        with app.app_context():
-            # Create token and mark as already used
+    def test_refresh_token_rejects_revoked_token(self):
+        """Test that endpoint rejects revoked tokens."""
+        with self.app.app_context():
             token_string = generate_refresh_token()
             token_hash = RefreshToken.hash_token(token_string)
-            family_id = uuid.uuid4()
-
-            refresh_token = RefreshToken(
-                token=token_hash,
-                user_id=test_user.id,
-                family_id=family_id,
-                created_on=datetime.utcnow(),
+            rt = RefreshToken(
+                user_id=self.test_user_id,
                 expires_on=datetime.utcnow() + timedelta(days=7),
-                revoked=False,
-                replaced_by=RefreshToken.hash_token("some_other_token"),
+                family_id=uuid.uuid4(),
             )
-            refresh_token.save()
+            rt.token = token_hash
+            rt.revoked = True
+            rt.save()
 
-        response = client.post(
+        response = self.client.post(
             "/token/refresh",
             json={"refresh_token": token_string},
         )
-        assert response.status_code == 401
-        assert "already been used" in response.json["message"]
+        self.assertEqual(response.status_code, 401)
+        self.assertIn("revoked", response.json["message"].lower())
 
-    def test_refresh_token_returns_new_tokens(self, app, client, test_user):
-        """Test that successful refresh returns new tokens."""
-        with app.app_context():
-            # Create valid token
+    def test_refresh_token_detects_reuse(self):
+        """Test that endpoint detects and blocks token reuse (theft detection)."""
+        with self.app.app_context():
+            token_string = generate_refresh_token()
+            token_hash = RefreshToken.hash_token(token_string)
+            rt = RefreshToken(
+                user_id=self.test_user_id,
+                expires_on=datetime.utcnow() + timedelta(days=7),
+                family_id=uuid.uuid4(),
+            )
+            rt.token = token_hash
+            rt.replaced_by = RefreshToken.hash_token("some_other_token")
+            rt.save()
+
+        response = self.client.post(
+            "/token/refresh",
+            json={"refresh_token": token_string},
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertIn("already been used", response.json["message"])
+
+    def test_refresh_token_returns_new_tokens(self):
+        """Test that a successful refresh returns a new token pair."""
+        with self.app.app_context():
             pair = generate_token_pair(
-                user_id=test_user.id,
-                payload_data={"email": test_user.email},
+                user_id=self.test_user_id,
+                payload_data={"email": self.test_user_email},
             )
 
-        response = client.post(
+        response = self.client.post(
             "/token/refresh",
             json={"refresh_token": pair["refresh_token"]},
         )
-        assert response.status_code == 200
+        self.assertEqual(response.status_code, 200)
         data = response.json["data"]
-        assert "access_token" in data
-        assert "refresh_token" in data
-        assert "token_type" in data
-        assert data["token_type"] == "Bearer"
+        self.assertIn("access_token", data)
+        self.assertIn("refresh_token", data)
+        self.assertIn("token_type", data)
+        self.assertEqual(data["token_type"], "Bearer")
 
-    def test_refresh_token_rotates_token(self, app, client, test_user):
-        """Test that old token is marked as replaced."""
-        with app.app_context():
-            # Create initial token
+    def test_refresh_token_rotates_token(self):
+        """Test that the old token is revoked and marked as replaced."""
+        with self.app.app_context():
             pair = generate_token_pair(
-                user_id=test_user.id,
-                payload_data={"email": test_user.email},
+                user_id=self.test_user_id,
+                payload_data={"email": self.test_user_email},
             )
             old_token_hash = RefreshToken.hash_token(pair["refresh_token"])
 
-        # Refresh the token
-        response = client.post(
+        response = self.client.post(
             "/token/refresh",
             json={"refresh_token": pair["refresh_token"]},
         )
-        assert response.status_code == 200
+        self.assertEqual(response.status_code, 200)
 
-        with app.app_context():
-            # Verify old token is marked as replaced
+        with self.app.app_context():
             old_token = RefreshToken.get_by_token(old_token_hash)
-            assert old_token is not None
-            assert old_token.revoked is True
-            assert old_token.replaced_by is not None
+            self.assertIsNotNone(old_token)
+            self.assertTrue(old_token.revoked)
+            self.assertIsNotNone(old_token.replaced_by)
 
 
-class TestLoginAndLogout:
+class TestLoginAndLogout(_TokenTestMixin, BaseTestClass):
     """Test login and logout with dual tokens."""
 
-    def test_login_returns_both_tokens(self, app, client, test_user):
-        """Test that login endpoint returns both access and refresh tokens."""
-        with app.app_context():
-            test_user.set_password("TestPassword123!")
-            test_user.active = True
-            test_user.save()
+    def setUp(self):
+        super().setUp()
+        self._create_token_test_user()
 
-        response = client.post(
+    def test_login_returns_both_tokens(self):
+        """Test that login endpoint returns both access and refresh tokens."""
+        response = self.client.post(
             "/login",
             json={
-                "email": test_user.email,
+                "email": self.test_user_email,
                 "password": "TestPassword123!",
             },
         )
-
         if response.status_code == 200:
             data = response.json["data"]
-            assert "access_token" in data
-            assert "refresh_token" in data
-            assert "token_type" in data
-            assert data["token_type"] == "Bearer"
+            self.assertIn("access_token", data)
+            self.assertIn("refresh_token", data)
+            self.assertIn("token_type", data)
+            self.assertEqual(data["token_type"], "Bearer")
 
-    def test_logout_revokes_tokens(self, app, client, test_user):
-        """Test that logout revokes user's refresh tokens."""
-        with app.app_context():
-            test_user.set_password("TestPassword123!")
-            test_user.active = True
-            test_user.save()
-
-            # Create tokens for user
-            pair = generate_token_pair(
-                user_id=test_user.id,
-                payload_data={"email": test_user.email},
+    def test_logout_revokes_tokens(self):
+        """Test that logout revokes user's refresh tokens (placeholder)."""
+        with self.app.app_context():
+            generate_token_pair(
+                user_id=self.test_user_id,
+                payload_data={"email": self.test_user_email},
             )
-
-        # Logout (simplified - normally would be authenticated)
-        # Note: Actual logout requires proper authentication headers
-        # This is a placeholder for manual verification
+        # Actual logout requires proper authentication headers.
+        # Placeholder for integration-level verification.
         pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_standard_routes.py
+++ b/tests/test_standard_routes.py
@@ -67,7 +67,7 @@ class BlogClientTestCase(BaseTestClass):
         self.assertIn("X-CSRFToken", res.headers)
         self.assertIsNotNone(res.headers.get("X-CSRFToken"))
         self.assertIsNotNone(data["data"]["user"])
-        self.assertIsNotNone(data["data"]["jwt"])
+        self.assertIsNotNone(data["data"]["access_token"])
         self.assertIn("You are now logged in.", data.get("message"))
 
     @unittest.skipIf(
@@ -87,7 +87,7 @@ class BlogClientTestCase(BaseTestClass):
         self.assertIn("X-CSRFToken", res.headers)
         self.assertIsNotNone(res.headers.get("X-CSRFToken"))
         self.assertIsNotNone(data["data"]["user"])
-        self.assertIsNotNone(data["data"]["jwt"])
+        self.assertIsNotNone(data["data"]["access_token"])
         self.assertIn("You are now logged in.", data.get("message"))
 
         # Request endpoint that requires authentication
@@ -120,7 +120,7 @@ class BlogClientTestCase(BaseTestClass):
         self.assertIn("X-CSRFToken", res.headers)
         self.assertIsNotNone(res.headers.get("X-CSRFToken"))
         self.assertIsNotNone(data["data"]["user"])
-        self.assertIsNotNone(data["data"]["jwt"])
+        self.assertIsNotNone(data["data"]["access_token"])
         self.assertIn("You are now logged in.", data.get("message"))
 
         # Disconnect from the app.
@@ -150,7 +150,7 @@ class BlogClientTestCase(BaseTestClass):
         self.assertIn("X-CSRFToken", res.headers)
         self.assertIsNotNone(res.headers.get("X-CSRFToken"))
         self.assertIsNotNone(data["data"]["user"])
-        self.assertIsNotNone(data["data"]["jwt"])
+        self.assertIsNotNone(data["data"]["access_token"])
         self.assertIn("You are now logged in.", data.get("message"))
 
         # Disconnect from the app.
@@ -190,7 +190,7 @@ class BlogClientTestCase(BaseTestClass):
         self.assertIn("X-CSRFToken", res.headers)
         self.assertIsNotNone(res.headers.get("X-CSRFToken"))
         self.assertIsNotNone(data["data"]["user"])
-        self.assertIsNotNone(data["data"]["jwt"])
+        self.assertIsNotNone(data["data"]["access_token"])
         self.assertIn("You are now logged in.", data.get("message"))
 
         # Add the role "artist"
@@ -235,7 +235,7 @@ class BlogClientTestCase(BaseTestClass):
         self.assertIn("X-CSRFToken", res.headers)
         self.assertIsNotNone(res.headers.get("X-CSRFToken"))
         self.assertIsNotNone(data["data"]["user"])
-        self.assertIsNotNone(data["data"]["jwt"])
+        self.assertIsNotNone(data["data"]["access_token"])
         self.assertIn("You are now logged in.", data.get("message"))
 
         # Add the role "artist"
@@ -277,7 +277,7 @@ class BlogClientTestCase(BaseTestClass):
         self.assertIn("X-CSRFToken", res.headers)
         self.assertIsNotNone(res.headers.get("X-CSRFToken"))
         self.assertIsNotNone(data["data"]["user"])
-        self.assertIsNotNone(data["data"]["jwt"])
+        self.assertIsNotNone(data["data"]["access_token"])
         self.assertIn("You are now logged in.", data.get("message"))
 
         # Add the role "artist"
@@ -318,11 +318,11 @@ class BlogClientTestCase(BaseTestClass):
         self.assertIn("X-CSRFToken", res.headers)
         self.assertIsNotNone(res.headers.get("X-CSRFToken"))
         self.assertIsNotNone(data["data"]["user"])
-        self.assertIsNotNone(data["data"]["jwt"])
+        self.assertIsNotNone(data["data"]["access_token"])
         self.assertIn("You are now logged in.", data.get("message"))
 
         # Add the role "artist"
-        data["data"].pop("jwt", None)
+        data["data"].pop("access_token", None)
         data["data"]["role"] = role
         res = self.add_role(data)
         data = json.loads(res.data)
@@ -435,7 +435,7 @@ class BlogClientTestCase(BaseTestClass):
         self.assertIn("X-CSRFToken", res.headers)
         self.assertIsNotNone(res.headers.get("X-CSRFToken"))
         self.assertIsNotNone(data["data"]["user"])
-        self.assertIsNotNone(data["data"]["jwt"])
+        self.assertIsNotNone(data["data"]["access_token"])
         self.assertIn("You are now logged in.", data.get("message"))
 
         # Add role Artist to the user
@@ -489,7 +489,7 @@ class BlogClientTestCase(BaseTestClass):
         self.assertIn("X-CSRFToken", res.headers)
         self.assertIsNotNone(res.headers.get("X-CSRFToken"))
         self.assertIsNotNone(data["data"]["user"])
-        self.assertIsNotNone(data["data"]["jwt"])
+        self.assertIsNotNone(data["data"]["access_token"])
         self.assertIn("You are now logged in.", data.get("message"))
 
         # Add role Artist to the user
@@ -671,7 +671,7 @@ class BlogClientTestCase(BaseTestClass):
 
         self.assertEqual(200, res.status_code)
         self.assertIn("X-CSRFToken", res.headers)
-        self.assertIsNotNone(data["data"]["jwt"])
+        self.assertIsNotNone(data["data"]["access_token"])
         self.assertIsNotNone(data["data"]["user"])
         self.assertIn("You are now logged in.", data.get("message"))
 


### PR DESCRIPTION
## Summary

Fixes all 12 failing tests in `test_standard_routes.py` and refactors `test_refresh_token.py` from pytest to unittest.

## Root Causes

### 1. Login response key rename (US-003)
The login route changed its response key from `jwt` to `access_token`. Four route handlers and two auth decorators were still hard-reading `json["data"]["jwt"]`, causing `KeyError` and unexpected 401 responses.

**Files fixed:**
- `core/users/routes/logout.py` — reads `data.get("jwt") or data.get("access_token")`
- `core/users/routes/roles.py` — same pattern
- `core/users/routes/sanity_check.py` — both `/protected` and `/protected-role` endpoints
- `core/auth/auth_guard.py` — `authorization_guard` decorator now accepts both keys
- `core/auth/payload_validator.py` — `validate_generic_payload` decorator same fix

### 2. JWT payload claim mismatch
`generate_token_pair()` (introduced in US-003) encoded `user_id` under `"sub"` (OAuth2 standard), but all downstream decoders expected `"GW-user-ID"` (`JWT_ENCODING_PARAM_1`). Added the legacy claim to the access token payload for backward compatibility.

**File fixed:**
- `core/auth/jwt/jwt_handler.py` — `generate_token_pair()` now includes both `sub` and `GW-user-ID` claims

### 3. Test assertions updated
- 11 assertEqual references to `data["data"]["jwt"]` updated to `access_token` for login-response checks
- `pop("jwt")` updated to `pop("access_token")`

### 4. test_refresh_token.py refactored
- Migrated from pytest fixtures/`assert` style to `unittest.TestCase` / `BaseTestClass` pattern (matching the rest of the test suite)
- Fixed `RefreshToken` constructor calls to use correct signature `(user_id, expires_on, family_id=None)`
- Fixed `token.py` import (`from application import db` → `from core import db`)

## Test Results
- `test_standard_routes.py`: **21/21 passed** (was 12 failing)
- `test_refresh_token.py`: **26/26 passed**